### PR TITLE
feature portefeuille overname datum

### DIFF
--- a/docs/100_producten/100_borgstelling/010_aanvragen-borgstelling/index.md
+++ b/docs/100_producten/100_borgstelling/010_aanvragen-borgstelling/index.md
@@ -135,3 +135,4 @@ De gebeurtenis wordt toegevoegd aan de gebeurtenissen verzameling van de krediet
 | 11     | Een pro-forma borgstelling mag maar 1 keer gebruikt worden in een aanvraag.                                                                 | Frank Dijkstra |
 | 12      | Gemeente moet afgeleid worden op basis van postcode gebied. Het postcode gebied mag niet worden opgeslagen.                          | Frank Dijkstra |
 | 13     | De aanvraag wordt een maatwerk aanvraag wanneer de afgeleide gemeente niet in de lijst van aangesloten gemeenten van de kredietbank voorkomt.   | Frank Dijkstra |
+| 14 | Kredieten vanuit een portefeuille overname moeten genegeerd worden wanneer de portefeuille overname datum van de kredietbank gevuld is en de uitbetaal datum kleiner is dan de opgegeven datum. | Frank Dijkstra |

--- a/docs/data-dictionary/models/kredietbank.yml
+++ b/docs/data-dictionary/models/kredietbank.yml
@@ -40,6 +40,11 @@ properties:
         example: d41341dc-7111-44f9-b823-108f01223704
     required:
       - schuldenknooppunt
+  portefeuille_overname_datum:
+    type: string
+    format: date
+    description: De minimale uitbetaal datum dat een krediet moet hebben om in aanmerking te kunnen komen voor een portefeuille overname.
+    example: 2022-01-01
 required:
   - kredietbank_id
   - naam


### PR DESCRIPTION
Met deze datum is het ook mogelijk om de portefeuille overname functie te gebruiken voor een gedeeltelijke portefeuille overname. Met deze use case kunnen kredietbanken eenvoudig al geborgde kredieten bij het waarborgfonds registreren nadat er een automatische koppeling met Allegro is gerealiseerd.