### PR TITLE
feature/pro-forma-aanvraag-statistiek-codes

### DIFF
--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -133,7 +133,7 @@ Functionaliteit: Borgstelling aanvragen
 
   Scenario: {{type}} met een onbekende borgstelling categorie
     Gegeven "{{type}}" borgstelling categorie is -1
-    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
     Dan is het Schuldenknooppunt bericht niet geaccepteerd
 #{{/types}}
 

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -1,29 +1,53 @@
 # language: nl
 Functionaliteit: Borgstelling aanvragen
 
-  Achtergrond:
-    Gegeven het kenmerk "093e08db-6791-454b-a172-068099514907"
-    En een kredietbank
-    En een exact koppeling
+  Achtergrond: 
+    Gegeven een kredietbank
+    Gegeven een exact koppeling
+    Gegeven borgstelling categorie met kenmerk 100
+    En borgstelling categorie premie is 10%
+    En borgstelling categorie accepteren vanaf € 0,00
+    En borgstelling categorie maatwerk vanaf € 5000,00
+    En borgstelling categorie afwijzen vanaf € 10000,00
+    Gegeven een pro forma borgstelling aanvraag met kenmerk "a8afa8cc-9a91-4722-82ca-95cff3770314"
+    En pro forma borgstelling aanvraag borgstelling categorie is 100
+    En pro forma borgstelling aanvraag bruto kredietsom van € 4999,99
+    En pro forma borgstelling aanvraag postcode gebied is "3743"
+    En pro forma borgstelling aanvraag looptijd van 36 maanden
+    En pro forma borgstelling aanvraag statistieken
+      | code                | waarde |
+      | Bevolkingsgroep     |      1 |
+      | Betalende instantie |      2 |
+      | Kredietdoel         |      3 |
+      | Leeftijdsgroep      |      4 |
+      | Soort borgstelling  |      5 |
+    En pro forma borgstelling aanvraag soort lening is "SK"
+    En pro forma borgstelling aanvraag contact emailadres "test@test.nl"
+    Gegeven een borgstelling aanvraag
+    En het kenmerk "093e08db-6791-454b-a172-068099514907"
+    En de borgstelling categorie is 100
     En een bruto kredietsom van € 4999,99
-    En een uitbetaaldatum
     En het postcode gebied is "3743"
     En een looptijd van 36 maanden
     En statistieken
       | code                | waarde |
-      | Bevolkingsgroep     | 1      |
-      | Betalende instantie | 2      |
-      | Kredietdoel         | 3      |
-      | Leeftijdsgroep      | 4      |
-      | Soort borgstelling  | 5      |
+      | Bevolkingsgroep     |      1 |
+      | Betalende instantie |      2 |
+      | Kredietdoel         |      3 |
+      | Leeftijdsgroep      |      4 |
+      | Soort borgstelling  |      5 |
     En soort lening is "SK"
     En een contact emailadres "test@test.nl"
+    Gegeven een portefeuille overname
+    En een uitbetaaldatum
     En een uitstaand saldo van € 2000,00
+#{{#types}}
 
-  Scenario: Aanvraag borgstelling wordt juist geregistreerd
-    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
+  Scenario: {{type}} wordt juist geregistreerd
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     Dan is het kenmerk juist geregistreerd
+    En de borgstelling categorie juist geregistreerd
     En is de bruto kredietsom juist geregistreerd
     En is de looptijd juist geregistreerd
     En is het soort lening juist geregistreerd
@@ -31,74 +55,105 @@ Functionaliteit: Borgstelling aanvragen
     En is het contact emailadres juist geregistreerd
     En is de geregistreerde gemeente "Baarn"
 
-  Scenario: Standaard borgstelling aanvragen
-    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
+  Scenario: {{type}} aanvragen
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is de status van de borgstelling "AFGEGEVEN"
+    Dan is de status van de "{{type}}" "AFGEGEVEN"
     En is "het contract" gearchiveerd
     En is er een verkoop geregistreerd van € 49,99
-    En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
+    En is het "{{type}} afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk borgstelling op basis van bruto kredietsom aanvragen
+  Scenario: Maatwerk {{type}} op basis van bruto kredietsom aanvragen
     Gegeven een bruto kredietsom van € 5000
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    En wachten enkele momenten
+    Dan is de status van de "{{type}}" "MAATWERK"
+    En is er een "beoordeel maatwerk borgstelling" taak actief
+
+  Scenario: {{type}} op basis van bruto kredietsom afwijzen
+    Gegeven een bruto kredietsom van € 10000
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is de status van de borgstelling "MAATWERK"
-    En is er een "beoordeel maatwerk borgstelling" taak actief
+    Dan is de status van de "{{type}}" "AFGEWEZEN"
+    En is er geen verkoop geregistreerd
+    En is het "{{type}} afgewezen" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk borgstelling op basis van looptijd aanvragen
+  Scenario: Maatwerk {{type}} op basis van looptijd aanvragen
     Gegeven een looptijd van 37 maanden
-    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is de status van de borgstelling "MAATWERK"
-    En is er een "beoordeel maatwerk borgstelling" taak actief
+    Dan is de status van de "{{type}}" "MAATWERK"
+    En is er een "beoordeel maatwerk {{type}}" taak actief
 
-  Scenario: Maatwerk borgstelling accepteren
+  Scenario: Maatwerk {{type}} accepteren
     Gegeven een bruto kredietsom van € 5000
-    En een "beoordeel maatwerk borgstelling" taak is actief
-    Wanneer de maatwerk taak is goedgekeurd
-    Dan is de status van de borgstelling "AFGEGEVEN"
+    En een "beoordeel maatwerk {{type}}" taak is actief
+    Wanneer de maatwerk "{{type}}" taak is goedgekeurd
+    Dan is de status van de "{{type}}" "AFGEGEVEN"
     En is "het contract" gearchiveerd
     En is er een verkoop geregistreerd van € 50,0
-    En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
+    En is het "{{type}} afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk borgstelling op basis van looptijd aanvragen
+  Scenario: Maatwerk {{type}} op basis van looptijd aanvragen
     Gegeven een looptijd van 37 maanden
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    En wachten enkele momenten
+    Dan is de status van de "{{type}}" "MAATWERK"
+    En is er een "beoordeel maatwerk {{type}}" taak actief
+
+  Scenario: Maatwerk {{type}} afwijzen
+    Gegeven een bruto kredietsom van € 5000
+    En een "beoordeel maatwerk {{type}}" taak is actief
+    Wanneer de "{{type}}" maatwerk taak is afgewezen met reden "89ed237c-5e3e-4dc4-9eef-eb5714671719"
+    Dan is de status van de "{{type}}" "AFGEWEZEN"
+    En is "de afwijzing" gearchiveerd
+    En bevat het document de tekst "89ed237c-5e3e-4dc4-9eef-eb5714671719"
+    En is er geen verkoop geregistreerd
+    En is het "{type}} afgewezen" bericht ontvangen door het Schuldenknooppunt
+
+  Abstract Scenario: {{type}} met verschillende status grenzen
+    Gegeven borgstelling categorie accepteren vanaf € <accepteren>
+    En borgstelling categorie maatwerk vanaf € <maatwerk>
+    En borgstelling categorie afwijzen vanaf € <afwijzen>
+    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    En wachten enkele momenten
+    Dan is de status van de "{{type}}" "AFGEWEZEN"
+
+    Voorbeelden: 
+      | accepteren | maatwerk | afwijzen | status    |
+      |          0 |     5000 |        0 | AFGEGEVEN |
+      |          0 |  4999,99 |        0 | MAATWERK  |
+      |          0 |        0 |  4999,99 | AFGEWEZEN |
+#{{/types}}
+
+  Abstract Scenario: Aanvraag borgstelling met verschillende premies
+    Gegeven een bruto kredietsom van € <bruto kredietsom>
+    En borgstelling categorie premie is <premie>%
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is de status van de borgstelling "MAATWERK"
-    En is er een "beoordeel maatwerk borgstelling" taak actief
+    En is er een verkoop geregistreerd van € <verkoop>
 
-  Scenario: Maatwerk borgstelling accepteren
-    Gegeven een bruto kredietsom van € 5000
-    En een "beoordeel maatwerk borgstelling" taak is actief
-    Wanneer de maatwerk taak is goedgekeurd
-    Dan is de status van de borgstelling "AFGEGEVEN"
-    En is "het contract" gearchiveerd
-    En is er een verkoop geregistreerd van € 50
-    En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
-
-  Scenario: Maatwerk borgstelling afwijzen
-    Gegeven een bruto kredietsom van € 5000
-    En een "beoordeel maatwerk borgstelling" taak is actief
-    Wanneer de maatwerk taak is afgekeurd
-    Dan is de status van de borgstelling "AFGEWEZEN"
-    En is "de afwijzing" gearchiveerd
-    En is er geen verkoop geregistreerd
-    En is het "borgstelling afgewezen" bericht ontvangen door het Schuldenknooppunt
+    Voorbeelden: 
+      | bruto kredietsom | premie | verkoop |
+      |          4999,99 |     10 |   49,99 |
+      |          2000,00 |     10 |   20,00 |
+      |          2000,00 |      5 |   10,00 |
 
   Scenario: Aanvraag borgstelling vanuit een portefeuille overname wordt juist geregistreerd
     Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is het uitstaand saldo juist geregistreerd
+    Dan is de uitbetaaldatum juist geregistreerd
+    En is het uitstaand saldo juist geregistreerd
 
-  Scenario: Standaard borgstelling aanvragen vanuit een portefeuille overname
-    Gegeven een looptijd van 35 maanden
+  Scenario: Aanvraag borgstelling vanuit een portefeuille overname premie op basis van uitstaand saldo
     Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
@@ -107,29 +162,16 @@ Functionaliteit: Borgstelling aanvragen
     En is er een verkoop geregistreerd van € 20
     En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Standaard borgstelling aanvragen vanuit een portefeuille overname op basis van uitstaand saldo
-    Gegeven een looptijd van 35 maanden
-    En een bruto kredietsom van € 5000
+  Scenario: Maatwerk aanvraag borgstelling vanuit een portefeuille overname op basis van verzekerd bedrag aanvragen
+    Gegeven een bruto kredietsom van € 5000
     En een uitstaand saldo van € 4999,99
-    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
-    En het Schuldenknooppunt bericht is verwerkt
-    En wachten enkele momenten
-    Dan is de status van de borgstelling "AFGEGEVEN"
-    En is "het contract" gearchiveerd
-    En is er een verkoop geregistreerd van € 49,99
-    En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
-
-  Scenario: Maatwerk borgstelling vanuit een portefeuille overname op basis van verzekerd bedrag aanvragen
-    Gegeven een looptijd van 35 maanden
-    En een bruto kredietsom van € 5000
-    En een uitstaand saldo van € 5000
     Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
     Dan is de status van de borgstelling "MAATWERK"
     En is er een "beoordeel maatwerk borgstelling" taak actief
 
-  Scenario: Maatwerk borgstelling vanuit een portefeuille overname op basis van looptijd afwijzen
+  Scenario: Aanvraag borgstelling vanuit een portefeuille overname op basis van uitbetaaldatum afwijzen
     Gegeven een uitbetaaldatum "2002-01-01"
     Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
@@ -139,48 +181,35 @@ Functionaliteit: Borgstelling aanvragen
     En is er geen verkoop geregistreerd
     En is het "borgstelling afgewezen" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Standaard borgstelling aanvragen met een borgstelling categorie maatwerk
-    Gegeven een borgstelling category "cat1" met premie: 10, en accepteren vanaf 0, en maatwerk vanaf 2000, en afgewezen vanaf 10000
-    En een bruto kredietsom van € 3000
-    En statistieken
-      | code               | waarde |
-      | Soort borgstelling | cat1   |
+  Abstract Scenario: Aanvraag borgstelling met pro forma aanvraag
+    Gegeven pro forma borgstelling aanvraag bruto kredietsom van € <pro forma bruto kredietsom>
+    En bruto kredietsom van € <bruto kredietsom>
+    En is de status van de pro forma borgstelling "<pro forma status>"
+    Gegeven aanvraag borgstelling met pro forma aanvraag
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is de status van de borgstelling "MAATWERK"
+    Dan is de status van de borgstelling "<status>"
 
-  Scenario: Standaard borgstelling aanvragen met een borgstelling categorie geaccepteerd
-    Gegeven een borgstelling category "cat1" met premie: 10, en accepteren vanaf 0, en maatwerk vanaf 2000, en afgewezen vanaf 10000
-    En een bruto kredietsom van € 1000
-    En statistieken
-      | code               | waarde |
-      | Soort borgstelling | cat1   |
+    Voorbeelden: 
+      | pro forma bruto kredietsom | pro forma status | bruto kredietsom | status    |
+      |                    4999,99 | AFGEGEVEN        |          4999,99 | AFGEGEVEN |
+      |                       5000 | AFGEWEZEN        |          4999,99 | AFGEGEVEN |
+      |                       5000 | AFGEGEVEN        |             5249 | AFGEGEVEN |
+      |                       5000 | AFGEGEVEN        |             5250 | MAATWERK  |
+      |                       6000 | AFGEGEVEN        |             5700 | MAATWERK  |
+
+  Abstract Scenario: Aanvraag borgstelling met pro forma aanvraag met afwijkende looptijden
+    Gegeven pro forma borgstelling aanvraag looptijd van <pro forma looptijd> maanden
+    En een looptijd van <looptijd> maanden
+    Gegeven aanvraag borgstelling met pro forma aanvraag
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    Dan is de status van de borgstelling "AFGEGEVEN"
-    En is er een verkoop geregistreerd van € 100,00
+    Dan is de status van de borgstelling "<status>"
 
-  Scenario: Standaard borgstelling aanvragen met een borgstelling categorie afgwezen
-    Gegeven een borgstelling category "cat1" met premie: 10, en accepteren vanaf 0, en maatwerk vanaf 2000, en afgewezen vanaf 10000
-    En een bruto kredietsom van € 10000
-    En statistieken
-      | code               | waarde |
-      | Soort borgstelling | cat1   |
-    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het Schuldenknooppunt bericht is verwerkt
-    En wachten enkele momenten
-    Dan is de status van de borgstelling "AFGEWEZEN"
-
-  Scenario: Standaard borgstelling aanvragen met een borgstelling categorie afgwezen zonder maatwerk mogelijkheid
-    Gegeven een borgstelling category "cat1" met premie: 10, en accepteren vanaf 0, en maatwerk vanaf 2000, en afgewezen vanaf 0
-    En een bruto kredietsom van € 2000
-    En statistieken
-      | code               | waarde |
-      | Soort borgstelling | cat1   |
-    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het Schuldenknooppunt bericht is verwerkt
-    En wachten enkele momenten
-    Dan is de status van de borgstelling "AFGEWEZEN"
-
+    Voorbeelden: 
+      | pro forma looptijd | looptijd | status    |
+      |                 36 |       35 | AFGEGEVEN |
+      |                 36 |       37 | MAATWERK  |
+      |                 37 |       36 | AFGEGEVEN |

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -41,11 +41,6 @@ Functionaliteit: Borgstelling aanvragen
     Gegeven een portefeuille overname
     En een uitbetaaldatum
     En een uitstaand saldo van € 2000,00
-
-  Scenario: {{type}} met een onbekende borgstelling categorie
-    Gegeven "{{type}}" borgstelling categorie is -1
-    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
-    Dan is het Schuldenknooppunt bericht niet geaccepteerd
 #{{#types}}
 
   Scenario: {{type}} wordt juist geregistreerd
@@ -135,6 +130,11 @@ Functionaliteit: Borgstelling aanvragen
       |          0 |     5000 |        0 | AFGEGEVEN |
       |          0 |  4999,99 |        0 | MAATWERK  |
       |          0 |        0 |  4999,99 | AFGEWEZEN |
+
+  Scenario: {{type}} met een onbekende borgstelling categorie
+    Gegeven "{{type}}" borgstelling categorie is -1
+    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
+    Dan is het Schuldenknooppunt bericht niet geaccepteerd
 #{{/types}}
 
   Abstract Scenario: Aanvraag borgstelling met verschillende premies

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -41,6 +41,11 @@ Functionaliteit: Borgstelling aanvragen
     Gegeven een portefeuille overname
     En een uitbetaaldatum
     En een uitstaand saldo van € 2000,00
+
+  Scenario: {{type}} met een onbekende borgstelling categorie
+    Gegeven "{{type}}" borgstelling categorie is -1
+    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
+    Dan is het Schuldenknooppunt bericht niet geaccepteerd
 #{{#types}}
 
   Scenario: {{type}} wordt juist geregistreerd

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature.yml
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature.yml
@@ -1,0 +1,3 @@
+types:
+  - type: Aanvraag borgstelling
+  - type: Pro forma aanvraag borgstelling

--- a/docs/data-dictionary/commands/registreer_borgstelling_aanvraag.yml
+++ b/docs/data-dictionary/commands/registreer_borgstelling_aanvraag.yml
@@ -4,9 +4,6 @@ allOf:
     description: |
       Een aanvraag borgstelling voor een nog te verstrekken saneringskrediet.
     properties:
-      soort_aanvraag:
-        type: string
-        example: aanvraag
       pro_forma_borgstelling:
         $ref: "../types/pro_forma_borgstelling_id.yml"
   - $ref: "../models/borgstelling_aanvraag.yml"

--- a/docs/data-dictionary/commands/registreer_borgstelling_aanvraag.yml
+++ b/docs/data-dictionary/commands/registreer_borgstelling_aanvraag.yml
@@ -9,9 +9,5 @@ allOf:
         example: aanvraag
       pro_forma_borgstelling:
         $ref: "../types/pro_forma_borgstelling_id.yml"
-      statistieken:
-        $ref: "../models/statistieken.yml"
-    required:
-      - statistieken
   - $ref: "../models/borgstelling_aanvraag.yml"
     

--- a/docs/data-dictionary/commands/registreer_borgstelling_overname.yml
+++ b/docs/data-dictionary/commands/registreer_borgstelling_overname.yml
@@ -11,10 +11,7 @@ allOf:
         $ref: "../types/saneringskrediet_uitstaand_saldo.yml"
       datum_uitbetaald:
         $ref: "../types/saneringskrediet_uitbetaaldatum.yml"
-      statistieken:
-        $ref: "../models/statistieken.yml"
     required:
       - uitstaand_saldo
       - datum_uitbetaald
-      - statistieken
   - $ref: "../models/borgstelling_aanvraag.yml"

--- a/docs/data-dictionary/commands/registreer_borgstelling_overname.yml
+++ b/docs/data-dictionary/commands/registreer_borgstelling_overname.yml
@@ -4,9 +4,6 @@ allOf:
     description: |
       Een borgstelling aanvraag vanuit een portefeuille overname van actieve saneringskredieten.
     properties:
-      soort_aanvraag:
-        type: string
-        example: overname
       uitstaand_saldo:
         $ref: "../types/saneringskrediet_uitstaand_saldo.yml"
       datum_uitbetaald:

--- a/docs/data-dictionary/commands/registreer_pro_forma_aanvraag.yml
+++ b/docs/data-dictionary/commands/registreer_pro_forma_aanvraag.yml
@@ -3,8 +3,4 @@ allOf:
   - title: registreer pro-forma aanvraag
     description: |
       Een aanvraag borgstelling voor een nog te verstrekken saneringskrediet.
-    properties:
-      soort_aanvraag:
-        type: string
-        example: aanvraag
   - $ref: "../models/borgstelling_aanvraag.yml"

--- a/docs/data-dictionary/models/borgstelling_aanvraag.yml
+++ b/docs/data-dictionary/models/borgstelling_aanvraag.yml
@@ -17,6 +17,8 @@ properties:
     $ref: "../types/bruto_kredietsom.yml"
   looptijd:
     $ref: "../types/looptijd_in_maanden.yml"
+  statistieken:
+    $ref: "../models/statistieken.yml"
 required:
   - soort_aanvraag
   - soort_lening
@@ -26,3 +28,4 @@ required:
   - postcode_gebied
   - bruto_kredietsom
   - looptijd
+  - statistieken

--- a/docs/data-dictionary/models/borgstelling_aanvraag.yml
+++ b/docs/data-dictionary/models/borgstelling_aanvraag.yml
@@ -1,11 +1,9 @@
 type: object
 title: borgstelling aanvraag
 properties:
-  soort_aanvraag:
-    $ref: "../types/soort_aanvraag.yml"
   soort_lening:
     $ref: "../types/soort_lening.yml"
-  categorie:
+  borgstelling_categorie:
     $ref: "../types/borgstelling_categorie_id.yml"
   kenmerk:
     $ref: "../types/kenmerk_aanvrager.yml"
@@ -20,9 +18,8 @@ properties:
   statistieken:
     $ref: "../models/statistieken.yml"
 required:
-  - soort_aanvraag
   - soort_lening
-  - categorie
+  - borgstelling_categorie
   - kenmerk
   - email
   - postcode_gebied

--- a/docs/data-dictionary/models/borgstelling_categorie.yml
+++ b/docs/data-dictionary/models/borgstelling_categorie.yml
@@ -22,19 +22,9 @@ properties:
       - geaccepteerd_vanaf
       - maatwerk_vanaf
       - afgewezen_vanaf
-  referenties:
-    type: object
-    properties:
-      statistiek:
-        allOf:
-          - description: Op basis van statisiek wordt de borgstelling categorie vastgesteld in de schuldenknooppunt adapter.
-          - $ref: "./statistiek.yml"
-    required:
-      - statistiek
 required:
   - borgstelling_categorie_id
   - naam
   - statisiek
   - premie_percentage
   - beslissingstabel
-  - referenties

--- a/docs/data-dictionary/types/borgstelling_categorie_id.yml
+++ b/docs/data-dictionary/types/borgstelling_categorie_id.yml
@@ -1,4 +1,4 @@
-type: string
-format: uuid
+type: integer
 description: Uniek identificerend kenmerk van de borgstelling categorie.
-example: d18843f6-fa00-49df-814a-1312326da0d0
+example: 100
+minimum: 1

--- a/docs/data-dictionary/types/borgstelling_categorie_naam.yml
+++ b/docs/data-dictionary/types/borgstelling_categorie_naam.yml
@@ -1,6 +1,10 @@
 type: string
 title: borgstelling categorie naam
 description: De naam van de borgstelling categorie.
+example: Regulier Saneringskrediet
 examples:
-  - Regulier
-  - Pilot JPF
+  - Regulier Saneringskrediet
+  - Pilot Flexibel Saneringskrediet
+  - Pilot Jongerenperspectieffonds
+  - Pilot Ondernemers
+  - Pilot Schuldhulpmaatje

--- a/docs/data-dictionary/types/soort_aanvraag.yml
+++ b/docs/data-dictionary/types/soort_aanvraag.yml
@@ -1,4 +1,0 @@
-type: string
-title: soort aanvraag
-description: Er bestaan verschillende soorten aanvragen. Via dit veld wordt vastgelegd om wat voor soort aanvraag het gaat.
-example: aanvraag


### PR DESCRIPTION
Het moet ook voor pro forma aanvragen mogelijk zijn om statistiek codes mee te geven zodat de borgstelling categorie vastgesteld kan worden.

Zie: https://wsk.sbn.nl/feature/pro-forma-aanvraag-statistiek-codes