### PR TITLE
Bugfixes/feature tests issues

### DIFF
--- a/.github/workflows/md-docs.yml
+++ b/.github/workflows/md-docs.yml
@@ -20,24 +20,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # aws s3 cp s3://wsk-valtimo-acc-cucumber-test-results-f1403diq .temp/executions/main/ --region eu-central-1 --recursive --no-sign-request
-
-      # - name: Download
-      #   uses: synionnl/md-docs-actions/azure/download@main
-      #   with:
-      #     credentials: ${{ secrets.AZURE_CREDENTIALS }}
-      #     storage_account: sbnstorage
-      #     storage_container: test-executions
-      #     github_token: ${{ github.token }}
-      #     repository: ${{ github.repository }}
-
       - name: Download
         run: |
           rm -rf ${EXECUTIONS_PATH}
           curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/borgstelling-aanvragen.json
           curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/borgstelling-aanvullen.json
           curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/borgstelling-beeindigen.json
-          # curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/borgstelling-intrekken.json
+          curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/borgstelling-uitbetalen.json
+          curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/herfiatteren.json
+          curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/portefeuille-overnemen.json
+          curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/pro-forma-aanvragen.json
+          curl --create-dirs -O --output-dir ${EXECUTIONS_PATH} ${TEST_RESULTS_BUCKET}/main/docs/100_producten/100_borgstelling/pro-forma-borgstelling-gebruiken.json
         env:
           TEST_RESULTS_BUCKET: https://wsk-valtimo-acc-cucumber-test-results-f1403diq.s3.eu-central-1.amazonaws.com
           EXECUTIONS_PATH: .temp/executions/main

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -132,7 +132,7 @@ Functionaliteit: Borgstelling aanvragen
     En is er een verkoop geregistreerd van € <verkoop>
 
     Voorbeelden:
-      | bruto kredietsom | premie | verkoop  |
-      | 4999,99          | 10     | 499,99   |
-      | 2000,00          | 10     | 200,00   |
-      | 2000,00          | 5      | 100,00   |
+      | bruto kredietsom | premie | verkoop |
+      | 4999,99          | 10     | 499,99  |
+      | 2000,00          | 10     | 200,00  |
+      | 2000,00          | 5      | 100,00  |

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -1,13 +1,11 @@
 # language: nl
 Functionaliteit: Borgstelling aanvragen
 
-  # Opmerkinen:
-  # wachten enkele momenten functionliteit verplaatsen naar is de status van de "{{type}}" "AFGEGEVEN"
   Achtergrond:
     Gegeven een kredietbank
     Gegeven een borgstelling categorie
       | kenmerk          | 100       |
-      | premie           | 10%       |
+      | premie           | 1%        |
       | accepteren vanaf | € 0,0     |
       | maatwerk vanaf   | € 5000,0  |
       | afwijzen vanaf   | € 10000,0 |
@@ -26,83 +24,82 @@ Functionaliteit: Borgstelling aanvragen
       | Kredietdoel         | 3      |
       | Leeftijdsgroep      | 4      |
       | Soort borgstelling  | 5      |
-  #{{#types}}
 
-  Scenario: {{type}} wordt juist geregistreerd
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+  Scenario: aanvraag borgstelling wordt juist geregistreerd
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de "{{type}}" juist geregistreerd
+    Dan is de "aanvraag borgstelling" juist geregistreerd
 
-  Scenario: Standaard {{type}} aanvragen
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+  Scenario: Standaard aanvraag borgstelling aanvragen
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de status van de "{{type}}" "AFGEGEVEN"
+    Dan is de status van de "aanvraag borgstelling" "AFGEGEVEN"
     En is "het contract" gearchiveerd
     En is er een verkoop geregistreerd van € 49,99
-    En is het "{{type}} afgegeven" bericht ontvangen door het Schuldenknooppunt
+    En is het "aanvraag borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk {{type}} op basis van bruto kredietsom aanvragen
-    Gegeven een {{type}} bericht
+  Scenario: Maatwerk aanvraag borgstelling op basis van bruto kredietsom aanvragen
+    Gegeven een aanvraag borgstelling bericht
       | bruto kredietsom | € 5000,0 |
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de status van de "{{type}}" "BEOORDEEL_AANVRAAG"
-    En is er een "beoordeel maatwerk {{type}}" taak actief
+    Dan is de status van de "aanvraag borgstelling" "BEOORDEEL_AANVRAAG"
+    En is er een "beoordeel maatwerk aanvraag borgstelling" taak actief
 
-  Scenario: {{type}} op basis van bruto kredietsom afwijzen
-    Gegeven een {{type}} bericht
+  Scenario: aanvraag borgstelling op basis van bruto kredietsom afwijzen
+    Gegeven een aanvraag borgstelling bericht
       | bruto kredietsom | € 10000,0 |
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de status van de "{{type}}" "AFGEWEZEN"
+    Dan is de status van de "aanvraag borgstelling" "AFGEWEZEN"
     En is er geen verkoop geregistreerd
-    En is het "{{type}} afgewezen" bericht ontvangen door het Schuldenknooppunt
+    En is het "aanvraag borgstelling afgewezen" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk {{type}} op basis van looptijd aanvragen
-    Gegeven een {{type}} bericht
+  Scenario: Maatwerk aanvraag borgstelling op basis van looptijd aanvragen
+    Gegeven een aanvraag borgstelling bericht
       | looptijd | 37 maanden |
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
-    En is er een "beoordeel maatwerk {{type}}" taak actief
+    En is er een "beoordeel maatwerk aanvraag borgstelling" taak actief
 
-  Scenario: Maatwerk {{type}} accepteren
-    Gegeven een {{type}} bericht
+  Scenario: Maatwerk aanvraag borgstelling accepteren
+    Gegeven een aanvraag borgstelling bericht
       | bruto kredietsom | € 5000,0 |
-    En een "beoordeel maatwerk {{type}}" taak is actief
-    Wanneer de "beoordeel maatwerk {{type}}" taak is goedgekeurd
-    Dan is de status van de "{{type}}" "AFGEGEVEN"
+    En een "beoordeel maatwerk aanvraag borgstelling" taak is actief
+    Wanneer de "beoordeel maatwerk aanvraag borgstelling" taak is goedgekeurd
+    Dan is de status van de "aanvraag borgstelling" "AFGEGEVEN"
     En is "het contract" gearchiveerd
     En is er een verkoop geregistreerd van € 50,0
-    En is het "{{type}} afgegeven" bericht ontvangen door het Schuldenknooppunt
+    En is het "aanvraag borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk {{type}} op basis van looptijd aanvragen
-    Gegeven een {{type}} bericht
+  Scenario: Maatwerk aanvraag borgstelling op basis van looptijd aanvragen
+    Gegeven een aanvraag borgstelling bericht
       | looptijd | 37 maanden |
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de status van de "{{type}}" "BEOORDEEL_AANVRAAG"
-    En is er een "beoordeel maatwerk {{type}}" taak actief
+    Dan is de status van de "aanvraag borgstelling" "BEOORDEEL_AANVRAAG"
+    En is er een "beoordeel maatwerk aanvraag borgstelling" taak actief
 
-  Scenario: Maatwerk {{type}} afwijzen
-    Gegeven een {{type}} bericht
+  Scenario: Maatwerk aanvraag borgstelling afwijzen
+    Gegeven een aanvraag borgstelling bericht
       | bruto kredietsom | € 5000,0 |
-    En een "beoordeel maatwerk {{type}}" taak is actief
-    Wanneer de "beoordeel maatwerk {{type}}" taak is afgewezen met reden "89ed237c-5e3e-4dc4-9eef-eb5714671719"
-    Dan is de status van de "{{type}}" "AFGEWEZEN"
+    En een "beoordeel maatwerk aanvraag borgstelling" taak is actief
+    Wanneer de "beoordeel maatwerk aanvraag borgstelling" taak is afgewezen met reden "89ed237c-5e3e-4dc4-9eef-eb5714671719"
+    Dan is de status van de "aanvraag borgstelling" "AFGEWEZEN"
     En is "de afwijzing" gearchiveerd
     En bevat "de afwijzing" de tekst "89ed237c-5e3e-4dc4-9eef-eb5714671719"
     En is er geen verkoop geregistreerd
-    En is het "{type}} afgewezen" bericht ontvangen door het Schuldenknooppunt
+    En is het "aanvraag borgstelling afgewezen" bericht ontvangen door het Schuldenknooppunt
 
-  Abstract Scenario: {{type}} met verschillende status grenzen
-    Gegeven borgstelling categorie
+  Abstract Scenario: aanvraag borgstelling met verschillende status grenzen
+    Gegeven een borgstelling categorie
       | accepteren vanaf | € <accepteren> |
       | maatwerk vanaf   | € <maatwerk>   |
       | afwijzen vanaf   | € <afwijzen>   |
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de status van de "{{type}}" "AFGEWEZEN"
+    Dan is de status van de "aanvraag borgstelling" "<status>"
 
     Voorbeelden:
       | accepteren | maatwerk | afwijzen | status             |
@@ -110,10 +107,11 @@ Functionaliteit: Borgstelling aanvragen
       | 0          | 4999,99  | 0        | BEOORDEEL_AANVRAAG |
       | 0          | 0        | 4999,99  | AFGEWEZEN          |
 
-  Abstract Scenario: {{type}} met een onbekende borgstelling categorie
-    Gegeven borgstelling categorie
+  Abstract Scenario: aanvraag borgstelling met een onbekende borgstelling categorie
+    Gegeven een borgstelling categorie
       | kenmerk | <kenmerk> |
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
     Dan is het Schuldenknooppunt bericht geaccepteerd
 
     Voorbeelden:
@@ -124,26 +122,18 @@ Functionaliteit: Borgstelling aanvragen
       | 400     |
       | 500     |
 
-  Scenario: {{type}} met een onbekende borgstelling categorie
-    Gegeven borgstelling categorie
-      | kenmerk | -1 |
-    Wanneer het "{{type}}" bericht is verstuurd via het Schuldenknooppunt
-    Dan is het Schuldenknooppunt bericht niet geaccepteerd
-  #{{/types}}
-
   Abstract Scenario: Aanvraag borgstelling met verschillende premies
     Gegeven een aanvraag borgstelling bericht
       | bruto kredietsom | € <bruto kredietsom> |
-    Gegeven borgstelling categorie
+    Gegeven een borgstelling categorie
       | premie | <premie>% |
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is de status van de "Aanvraag borgstelling" "AFGEGEVEN"
+    Dan is de status van de "aanvraag borgstelling" "AFGEGEVEN"
     En is er een verkoop geregistreerd van € <verkoop>
 
     Voorbeelden:
-      | bruto kredietsom | premie | verkoop |
-      | 4999,99          | 10     | 49,99   |
-      | 2000,00          | 10     | 20,00   |
-      | 2000,00          | 5      | 10,00   |
-
+      | bruto kredietsom | premie | verkoop  |
+      | 4999,99          | 10     | 499,99   |
+      | 2000,00          | 10     | 200,00   |
+      | 2000,00          | 5      | 100,00   |

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature
@@ -60,7 +60,6 @@ Functionaliteit: Borgstelling aanvragen
       | looptijd | 37 maanden |
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    En wachten enkele momenten
     En is er een "beoordeel maatwerk aanvraag borgstelling" taak actief
 
   Scenario: Maatwerk aanvraag borgstelling accepteren
@@ -112,7 +111,7 @@ Functionaliteit: Borgstelling aanvragen
       | kenmerk | <kenmerk> |
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
-    Dan is het Schuldenknooppunt bericht geaccepteerd
+    Dan is de "aanvraag borgstelling" juist geregistreerd
 
     Voorbeelden:
       | kenmerk |

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature.yml
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvragen.feature.yml
@@ -1,3 +1,0 @@
-types:
-  - type: aanvraag borgstelling
-  - type: pro forma aanvraag borgstelling

--- a/docs/100_producten/100_borgstelling/borgstelling-aanvullen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-aanvullen.feature
@@ -7,38 +7,38 @@ Functionaliteit: Borgstelling aanvullen
       | kenmerk | SK-1232432-2 |
     Gegeven een borgstelling
       | kenmerk | SK-323232-1 |
-    Gegeven kredietinformatie
+    Gegeven kredietinformatie bericht
       | kenmerk                       | SK-1232432-2 |
       | uitbetaaldatum                | 2022-06-01   |
       | bruto kredietsom              | € 1825,34    |
       | netto kredietsom              | € 1550,77    |
       | laatste aflosdatum            | 2022-08-01   |
-      | betaling aflossing            | 300,47       |
-      | betaling kredietvergoeding    | 24,45        |
-      | betaling vertragingsrente     | 4,45         |
-      | betaling boete rente          | 1,12         |
-      | achterstand aflossing         | 100,17       |
-      | achterstand kredietvergoeding | 5,87         |
-      | achterstand vertragingsrente  | 0,78         |
-      | achterstand boete rente       | 0,02         |
-      | voorstand                     | 10,15        |
+      | betaling aflossing            | € 300,47     |
+      | betaling kredietvergoeding    | € 24,45      |
+      | betaling vertragingsrente     | € 4,45       |
+      | betaling boete rente          | € 1,12       |
+      | achterstand aflossing         | € 100,17     |
+      | achterstand kredietvergoeding | € 5,87       |
+      | achterstand vertragingsrente  | € 0,78       |
+      | achterstand boete rente       | € 0,02       |
+      | voorstand                     | € 10,15      |
       | betalingsregeling             | ja           |
       | dubieus                       | ja           |
-    Gegeven kredietinformatie
+    Gegeven kredietinformatie bericht
       | kenmerk                       | SK-323232-1 |
       | uitbetaaldatum                | 2022-01-05  |
       | bruto kredietsom              | € 2300,98   |
       | netto kredietsom              | € 2198,34   |
       | laatste aflosdatum            | 2022-09-02  |
-      | betaling aflossing            | 233,64      |
-      | betaling kredietvergoeding    | 12,34       |
-      | betaling vertragingsrente     | 2,01        |
-      | betaling boete rente          | 0,23        |
-      | achterstand aflossing         | 99,23       |
-      | achterstand kredietvergoeding | 2,23        |
-      | achterstand vertragingsrente  | 0,2         |
-      | achterstand boete rente       | 0,12        |
-      | voorstand                     | 1,23        |
+      | betaling aflossing            | € 233,64    |
+      | betaling kredietvergoeding    | € 12,34     |
+      | betaling vertragingsrente     | € 2,01      |
+      | betaling boete rente          | € 0,23      |
+      | achterstand aflossing         | € 99,23     |
+      | achterstand kredietvergoeding | € 2,23      |
+      | achterstand vertragingsrente  | € 0,2       |
+      | achterstand boete rente       | € 0,12      |
+      | voorstand                     | € 1,23      |
       | betalingsregeling             | nee         |
       | dubieus                       | nee         |
 

--- a/docs/100_producten/100_borgstelling/borgstelling-beeindigen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-beeindigen.feature
@@ -13,7 +13,7 @@ Functionaliteit: Borgstelling beëindigen
       | kenmerk           | SK-11111-1 |
       | beeindigingsdatum | 2022-01-01 |
     Wanneer het "beëindiging borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het "beëindiging borgstelling" bericht is verwerkt
+    En het Schuldenknooppunt bericht is verwerkt
     Dan is de status van de borgstelling "BEEINDIGD"
     En is "de beëindiging" gearchiveerd
     En is beëindiging juist geregistreerd

--- a/docs/100_producten/100_borgstelling/borgstelling-uitbetalen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-uitbetalen.feature
@@ -47,6 +47,7 @@ Functionaliteit: Borgstelling uitbetalen
     Gegeven een borgstelling
       | status | <status> |
     Wanneer het "uitbetalen borgstelling" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
     Dan is het Schuldenknooppunt bericht niet geaccepteerd
 
     Voorbeelden:

--- a/docs/100_producten/100_borgstelling/borgstelling-uitbetalen.feature
+++ b/docs/100_producten/100_borgstelling/borgstelling-uitbetalen.feature
@@ -1,6 +1,7 @@
 # language: nl
 Functionaliteit: Borgstelling uitbetalen
 
+  Achtergrond:
     Gegeven een kredietbank
     Gegeven een borgstelling
       | kenmerk | SK-11111-1 |
@@ -10,13 +11,13 @@ Functionaliteit: Borgstelling uitbetalen
 
   Scenario: Borgstelling uitbetaling aanvragen
     Wanneer het "uitbetalen borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het "uitbetalen borgstelling" bericht is verwerkt
+    En het Schuldenknooppunt bericht is verwerkt
     Dan is de status van de borgstelling "BEOORDEEL_UITBETALING"
     En is er een "beoordeel uitbetaling" taak actief
 
   Scenario: Borgstelling uitbetaling aanvraag goedkeuren
     Wanneer het "uitbetalen borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het "uitbetalen borgstelling" bericht is verwerkt
+    En het Schuldenknooppunt bericht is verwerkt
     Dan is de status van de borgstelling "BEOORDEEL_UITBETALING"
     En is er een "beoordeel uitbetaling" taak actief
     Wanneer de "beoordeel uitbetaling" taak is goedgekeurd
@@ -25,33 +26,21 @@ Functionaliteit: Borgstelling uitbetalen
       | kredietvergoeding | € 24,45   |
       | lopende_rente     | € 0,12    |
       | voorstand         | € 10,15   |
-    Dan is de status van de "{{type}}" "UITBETAALD"
+    Dan is de status van de borgstelling "UITBETAALD"
     En is "de uitbetaling" gearchiveerd
     En is er een uitbetaling geregistreerd van € 1264,72
     En is het "borgstelling uitbetaald" bericht ontvangen door het Schuldenknooppunt
 
   Scenario: Borgstelling uitbetaling aanvraag afwijzen
     Wanneer het "uitbetalen borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het "uitbetalen borgstelling" bericht is verwerkt
+    En het Schuldenknooppunt bericht is verwerkt
     Dan is de status van de borgstelling "BEOORDEEL_UITBETALING"
     En is er een "beoordeel uitbetaling" taak actief
     Wanneer de "beoordeel uitbetaling" taak is afgewezen
       | reden | 879a7226-eb98-43d5-a32b-63227e868cc8 |
-    Dan is de status van de "{{type}}" "UITBETALING_AFGEWEZEN"
+    Dan is de status van de borgstelling "AFGEGEVEN"
     En is "de uitbetaling afwijzing" gearchiveerd
     En bevat "de uitbetaling afwijzing" de tekst "879a7226-eb98-43d5-a32b-63227e868cc8"
-    En is het "uitbetaaling afwijzing" bericht ontvangen door het Schuldenknooppunt
-
-  Scenario: Borgstelling uitbetaling aanvraag voorlopig afwijzen
-    Wanneer het "uitbetalen borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het "uitbetalen borgstelling" bericht is verwerkt
-    Dan is de status van de borgstelling "BEOORDEEL_UITBETALING"
-    En is er een "beoordeel uitbetaling" taak actief
-    Wanneer de "beoordeel uitbetaling" taak is voorlopig afgewezen
-      | reden | 97f027a1-ef9f-409e-bae5-02c27b09ebe1 |
-    Dan is de status van de "{{type}}" "UITBETALING_VOORLOPIG_AFGEWEZEN"
-    En is "de uitbetaling afwijzing" gearchiveerd
-    En bevat "de uitbetaling afwijzing" de tekst "97f027a1-ef9f-409e-bae5-02c27b09ebe1"
     En is het "uitbetaaling afwijzing" bericht ontvangen door het Schuldenknooppunt
 
   Abstract Scenario: Borgstelling uitbetaling aanvragen met een onjuiste status
@@ -66,7 +55,6 @@ Functionaliteit: Borgstelling uitbetalen
       | AANVRAAG_BEEINDIGD    |
       | BEEINDIGD             |
       | UITBETAALD            |
-      | UITBETALING_AFGEWEZEN |
       | BEOORDEEL_AANVRAAG    |
       | INGETROKKEN           |
       | WORDT_INGETROKKEN     |

--- a/docs/100_producten/100_borgstelling/borgstelling.dashboard.yml
+++ b/docs/100_producten/100_borgstelling/borgstelling.dashboard.yml
@@ -1,8 +1,8 @@
 - borgstelling-aanvragen.feature
-- pro-forma-aanvragen.feature
 - borgstelling-aanvullen.feature
 - borgstelling-beeindigen.feature
 - borgstelling-uitbetalen.feature
 - herfiatteren.feature
 - portefeuille-overnemen.feature
+- pro-forma-aanvragen.feature
 - pro-forma-borgstelling-gebruiken.feature

--- a/docs/100_producten/100_borgstelling/borgstelling.dashboard.yml
+++ b/docs/100_producten/100_borgstelling/borgstelling.dashboard.yml
@@ -1,4 +1,5 @@
 - borgstelling-aanvragen.feature
+- pro-forma-aanvragen.feature
 - borgstelling-aanvullen.feature
 - borgstelling-beeindigen.feature
 - borgstelling-uitbetalen.feature

--- a/docs/100_producten/100_borgstelling/herfiatteren.feature
+++ b/docs/100_producten/100_borgstelling/herfiatteren.feature
@@ -5,7 +5,7 @@ Functionaliteit: Herfiatteren
     Gegeven een kredietbank
     Gegeven een borgstelling categorie
       | kenmerk          | 100       |
-      | premie           | 10%       |
+      | premie           | 1%        |
       | accepteren vanaf | € 0,0     |
       | maatwerk vanaf   | € 5000,0  |
       | afwijzen vanaf   | € 10000,0 |
@@ -36,13 +36,12 @@ Functionaliteit: Herfiatteren
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     Dan zijn er 2 borgstelling aanvragen actief
-    En is de status van de borgstelling "WACHTEN"
-    Wanneer de "beoordeel maatwerk borgstelling aanvraag" taak is goedgekeurd
+    Wanneer de "beoordeel maatwerk aanvraag borgstelling" taak is goedgekeurd
     En is de status van de borgstelling "AFGEGEVEN"
     En is "het contract" gearchiveerd
-    En is er één verkoop geregistreerd van € 49,99
+    En is er één verkoop geregistreerd van € 50,00
     En is er geen verkoop geregistreerd van € 20,00
-    En is het "borgstelling afgegeven" bericht 2 keer ontvangen door het Schuldenknooppunt
+    En is het "aanvraag borgstelling afgegeven" bericht 2 keer ontvangen door het Schuldenknooppunt
 
   Scenario: Borgstelling aanvraag met afgeronde borgstelling aanvraag
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
@@ -55,4 +54,4 @@ Functionaliteit: Herfiatteren
     Dan is de status van de borgstelling "AFGEGEVEN"
     En is er één verkoop geregistreerd van € 49,99
     En is er geen verkoop geregistreerd van € 20,00
-    En is het "borgstelling afgegeven" bericht 2 keer ontvangen door het Schuldenknooppunt
+    En is het "aanvraag borgstelling afgegeven" bericht 2 keer ontvangen door het Schuldenknooppunt

--- a/docs/100_producten/100_borgstelling/portefeuille-overnemen.feature
+++ b/docs/100_producten/100_borgstelling/portefeuille-overnemen.feature
@@ -5,7 +5,7 @@ Functionaliteit: Portefeuille overnemen
     Gegeven een kredietbank
     Gegeven een borgstelling categorie
       | kenmerk          | 100       |
-      | premie           | 10%       |
+      | premie           | 1%       |
       | accepteren vanaf | € 0,0     |
       | maatwerk vanaf   | € 5000,0  |
       | afwijzen vanaf   | € 10000,0 |
@@ -17,7 +17,7 @@ Functionaliteit: Portefeuille overnemen
       | looptijd               | 36 maanden                           |
       | soort lening           | SK                                   |
       | contact emailadres     | test@test.nl                         |
-      | uitbetaaldatum         | 01-01-2023                           |
+      | uitbetaaldatum         | 2023-01-01                           |
       | uitstaand saldo        | € 2000,00                            |
     En portefeuille overname bericht statistieken
       | code                | waarde |
@@ -40,20 +40,20 @@ Functionaliteit: Portefeuille overnemen
     En is er een verkoop geregistreerd van € 20,0
     En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Scenario: Maatwerk aanvraag borgstelling vanuit een portefeuille overname op basis van verzekerd bedrag aanvragen
-    Gegeven een aanvraag overname bericht
-      | bruto kredietsom | € 5000,0  |
-      | uitstaand saldo  | € 4999,99 |
-    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
+  Abstract Scenario: Maatwerk aanvraag borgstelling vanuit een portefeuille overname op basis van verzekerd bedrag aanvragen
+    Gegeven een portefeuille overname bericht
+      | bruto kredietsom | € 5000  |
+      | uitstaand saldo  | € 5001  |
+    Wanneer het "portefeuille overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
     Dan is de status van de borgstelling "BEOORDEEL_AANVRAAG"
     En is er een "beoordeel maatwerk aanvraag borgstelling" taak actief
 
   Scenario: Aanvraag borgstelling vanuit een portefeuille overname op basis van uitbetaaldatum afwijzen
-    Gegeven een aanvraag overname bericht
+    Gegeven een portefeuille overname bericht
       | uitbetaaldatum | 2002-01-01 |
-    Wanneer het "aanvraag overname" bericht is verstuurd via het Schuldenknooppunt
+    Wanneer het "portefeuille overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten
     Dan is de status van de borgstelling "AFGEWEZEN"

--- a/docs/100_producten/100_borgstelling/portefeuille-overnemen.feature
+++ b/docs/100_producten/100_borgstelling/portefeuille-overnemen.feature
@@ -5,7 +5,7 @@ Functionaliteit: Portefeuille overnemen
     Gegeven een kredietbank
     Gegeven een borgstelling categorie
       | kenmerk          | 100       |
-      | premie           | 1%       |
+      | premie           | 1%        |
       | accepteren vanaf | € 0,0     |
       | maatwerk vanaf   | € 5000,0  |
       | afwijzen vanaf   | € 10000,0 |
@@ -32,7 +32,7 @@ Functionaliteit: Portefeuille overnemen
     En het Schuldenknooppunt bericht is verwerkt
     Dan is de "portefeuille overname" juist geregistreerd
 
-  Scenario: Aanvraag borgstelling vanuit een portefeuille overname premie op basis van uitstaand saldo
+  Abstract Scenario: Aanvraag borgstelling vanuit een portefeuille overname premie op basis van uitstaand saldo
     Wanneer het "portefeuille overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     Dan is de status van de borgstelling "AFGEGEVEN"
@@ -40,10 +40,15 @@ Functionaliteit: Portefeuille overnemen
     En is er een verkoop geregistreerd van € 20,0
     En is het "borgstelling afgegeven" bericht ontvangen door het Schuldenknooppunt
 
-  Abstract Scenario: Maatwerk aanvraag borgstelling vanuit een portefeuille overname op basis van verzekerd bedrag aanvragen
+    Voorbeelden:
+      | bruto kredietsom | uitstaand saldo | verkoop |
+      | € 4999,99        | € 2000          | € 20,0  |
+      | € 6000           | € 4999,99       | € 49,99 |
+
+  Scenario: Maatwerk aanvraag borgstelling vanuit een portefeuille overname op basis van verzekerd bedrag aanvragen
     Gegeven een portefeuille overname bericht
-      | bruto kredietsom | € 5000  |
-      | uitstaand saldo  | € 5001  |
+      | bruto kredietsom | € 6000 |
+      | uitstaand saldo  | € 5001 |
     Wanneer het "portefeuille overname" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     En wachten enkele momenten

--- a/docs/100_producten/100_borgstelling/pro-forma-aanvragen.feature
+++ b/docs/100_producten/100_borgstelling/pro-forma-aanvragen.feature
@@ -1,0 +1,113 @@
+# language: nl
+Functionaliteit: Pro forma aanvragen borgstelling
+
+  Achtergrond:
+    Gegeven een kredietbank
+    Gegeven een borgstelling categorie
+      | kenmerk          | 100       |
+      | premie           | 1%        |
+      | accepteren vanaf | € 0,0     |
+      | maatwerk vanaf   | € 5000,0  |
+      | afwijzen vanaf   | € 10000,0 |
+    Gegeven een pro-forma aanvraag bericht
+      | kenmerk                | 093e08db-6791-454b-a172-068099514907 |
+      | borgstelling categorie | 100                                  |
+      | bruto kredietsom       | € 4999,99                            |
+      | postcode               | 3743                                 |
+      | looptijd               | 36 maanden                           |
+      | soort lening           | SK                                   |
+      | contact emailadres     | test@test.nl                         |
+
+  Scenario: pro-forma aanvraag wordt juist geregistreerd
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de "pro-forma aanvraag" juist geregistreerd
+
+  Scenario: Standaard pro-forma aanvraag aanvragen
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de status van de "pro-forma aanvraag" "AFGEGEVEN"
+    En is "het pro-forma contract" gearchiveerd
+    En is het "pro-forma aanvraag afgegeven" bericht ontvangen door het Schuldenknooppunt
+
+  Scenario: Maatwerk pro-forma aanvraag op basis van bruto kredietsom aanvragen
+    Gegeven een pro-forma aanvraag bericht
+      | bruto kredietsom | € 5000,0 |
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de status van de "pro-forma aanvraag" "BEOORDEEL_AANVRAAG"
+    En is er een "beoordeel maatwerk pro-forma aanvraag" taak actief
+
+  Scenario: pro-forma aanvraag op basis van bruto kredietsom afwijzen
+    Gegeven een pro-forma aanvraag bericht
+      | bruto kredietsom | € 10000,0 |
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de status van de "pro-forma aanvraag" "BEOORDEEL_AANVRAAG"
+    En is er een "beoordeel maatwerk pro-forma aanvraag" taak actief
+
+  Scenario: Maatwerk pro-forma aanvraag op basis van looptijd aanvragen
+    Gegeven een pro-forma aanvraag bericht
+      | looptijd | 37 maanden |
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de status van de "pro-forma aanvraag" "BEOORDEEL_AANVRAAG"
+    En is er een "beoordeel maatwerk pro-forma aanvraag" taak actief
+
+  Scenario: Maatwerk pro-forma aanvraag accepteren
+    Gegeven een pro-forma aanvraag bericht
+      | bruto kredietsom | € 5000,0 |
+    En een "beoordeel maatwerk pro-forma aanvraag" taak is actief
+    Wanneer de "beoordeel maatwerk pro-forma aanvraag" taak is goedgekeurd
+    Dan is de status van de "pro-forma aanvraag" "AFGEGEVEN"
+    En is "het pro-forma contract" gearchiveerd
+    En is het "pro-forma aanvraag afgegeven" bericht ontvangen door het Schuldenknooppunt
+
+  Scenario: Maatwerk pro-forma aanvraag op basis van looptijd aanvragen
+    Gegeven een pro-forma aanvraag bericht
+      | looptijd | 37 maanden |
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de status van de "pro-forma aanvraag" "BEOORDEEL_AANVRAAG"
+    En is er een "beoordeel maatwerk pro-forma aanvraag" taak actief
+
+  Scenario: Maatwerk pro-forma aanvraag afwijzen
+    Gegeven een pro-forma aanvraag bericht
+      | bruto kredietsom | € 5000,0 |
+    En een "beoordeel maatwerk pro-forma aanvraag" taak is actief
+    Wanneer de "beoordeel maatwerk pro-forma aanvraag" taak is afgewezen met reden "89ed237c-5e3e-4dc4-9eef-eb5714671719"
+    Dan is de status van de "pro-forma aanvraag" "AFGEWEZEN"
+    En is "de pro-forma afwijzing" gearchiveerd
+    En bevat "de afwijzing" de tekst "89ed237c-5e3e-4dc4-9eef-eb5714671719"
+    En is er geen verkoop geregistreerd
+    En is het "pro-forma aanvraag afgewezen" bericht ontvangen door het Schuldenknooppunt
+
+  Abstract Scenario: pro-forma aanvraag met verschillende status grenzen
+    Gegeven een borgstelling categorie
+      | accepteren vanaf | € <accepteren> |
+      | maatwerk vanaf   | € <maatwerk>   |
+      | afwijzen vanaf   | € <afwijzen>   |
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de status van de "pro-forma aanvraag" "<status>"
+
+    Voorbeelden:
+      | accepteren | maatwerk | afwijzen | status             |
+      | 0          | 5000     | 0        | AFGEGEVEN          |
+      | 0          | 4999,99  | 0        | BEOORDEEL_AANVRAAG |
+      | 0          | 0        | 4999,99  | BEOORDEEL_AANVRAAG |
+
+  Abstract Scenario: pro-forma aanvraag met een onbekende borgstelling categorie
+    Gegeven een borgstelling categorie
+      | kenmerk | <kenmerk> |
+    Wanneer het "pro-forma aanvraag" bericht is verstuurd via het Schuldenknooppunt
+    En het Schuldenknooppunt bericht is verwerkt
+    Dan is de "pro-forma aanvraag" juist geregistreerd
+
+    Voorbeelden:
+      | kenmerk |
+      | 100     |
+      | 200     |
+      | 300     |
+      | 400     |
+      | 500     |

--- a/docs/100_producten/100_borgstelling/pro-forma-borgstelling-gebruiken.feature
+++ b/docs/100_producten/100_borgstelling/pro-forma-borgstelling-gebruiken.feature
@@ -2,9 +2,11 @@
 Functionaliteit: Pro-forma borgstelling gebruiken
 
   Achtergrond:
+    Gegeven een kredietbank
     Gegeven een pro-forma borgstelling
       | borgstelling id  | 0955bece-b75a-4368-b9d3-5c5a2596e920 |
       | bruto kredietsom | € 4999,99                            |
+      | looptijd         | 36 maanden                           |
       | status           | AFGEGEVEN                            |
     Gegeven een aanvraag borgstelling bericht
       | kenmerk                   | 093e08db-6791-454b-a172-068099514907 |
@@ -27,8 +29,6 @@ Functionaliteit: Pro-forma borgstelling gebruiken
     Gegeven een pro-forma borgstelling
       | bruto kredietsom | € <pro forma bruto kredietsom> |
       | status           | <pro forma status>             |
-    Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
-    En het Schuldenknooppunt bericht is verwerkt
     Gegeven een aanvraag borgstelling bericht
       | bruto kredietsom | € <bruto kredietsom> |
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
@@ -45,9 +45,9 @@ Functionaliteit: Pro-forma borgstelling gebruiken
 
   Abstract Scenario: Aanvraag borgstelling met pro forma aanvraag met afwijkende looptijden
     Gegeven een pro-forma borgstelling
-      | looptijd | <looptijd> maanden |
-    Gegeven een aanvraag borgstelling bericht
       | looptijd | <pro forma looptijd> maanden |
+    Gegeven een aanvraag borgstelling bericht
+      | looptijd | <looptijd> maanden |
     Wanneer het "aanvraag borgstelling" bericht is verstuurd via het Schuldenknooppunt
     En het Schuldenknooppunt bericht is verwerkt
     Dan is de status van de borgstelling "<status>"
@@ -57,3 +57,4 @@ Functionaliteit: Pro-forma borgstelling gebruiken
       | 36                 | 35       | AFGEGEVEN          |
       | 36                 | 37       | BEOORDEEL_AANVRAAG |
       | 37                 | 36       | AFGEGEVEN          |
+      | 37                 | 37       | AFGEGEVEN          |


### PR DESCRIPTION
Enkele bugfixes m.b.t. waardes en consistency tussen steps.

Scenario "Borgstelling uitbetaling aanvraag voorlopig afwijzen" verwijderd aangezien er geen "voorlopig" afwijzen pad is.

Scenario {{type}} met een onbekende borgstelling categorie verwijderd, want onbekend categorie valt terug op standaard accepteren.

Pro-forma aanvragen en aanvragen gesplitst aangezien er een verschil is tussen de resultaten van het process, pro-forma aanvragen worden nooit automatisch afgewezen.